### PR TITLE
Remove python requires

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -11,9 +11,6 @@ packages = [
     { include = "kubernetes-stubs" },
 ]
 
-[tool.poetry.dependencies]
-python = "^3.9"
-
 [tool.poetry.dev-dependencies]
 black = "^21.6b0"
 isort = "^5.9.2"


### PR DESCRIPTION
I've tested that running python -m build produces an installable package. Is there any other places I should change?