### PR TITLE
Fix import resolution error

### DIFF
--- a/kubernetes-stubs/config/__init__.pyi
+++ b/kubernetes-stubs/config/__init__.pyi
@@ -1,7 +1,11 @@
-from kubernetes.config.config_exception import ConfigException
-from kubernetes.config.incluster_config import load_incluster_config
-from kubernetes.config.kube_config import (KUBE_CONFIG_DEFAULT_LOCATION,
-                                           list_kube_config_contexts,
-                                           load_kube_config,
-                                           load_kube_config_from_dict,
-                                           new_client_from_config)
+from kubernetes.config.config_exception import ConfigException as ConfigException
+from kubernetes.config.incluster_config import (
+    load_incluster_config as load_incluster_config,
+)
+from kubernetes.config.kube_config import (
+    KUBE_CONFIG_DEFAULT_LOCATION as KUBE_CONFIG_DEFAULT_LOCATION,
+    list_kube_config_contexts as list_kube_config_contexts,
+    load_kube_config as load_kube_config,
+    load_kube_config_from_dict as load_kube_config_from_dict,
+    new_client_from_config as new_client_from_config,
+)


### PR DESCRIPTION
Fixed import resolution error like below.
```
$ cat sample.py
from kubernetes.config import load_kube_config
load_kube_config()
$ mypy sample.py
sample.py:1: error: Module "kubernetes.config" has no attribute "load_kube_config"; maybe "load_kube_config_from_dict" or "load_incluster_config"?
Found 1 error in 1 file (checked 1 source file)
```